### PR TITLE
Add Linux and Nix support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,9 @@
+# The nightly compiler gives best performance
+# For rust stable, remove the "-Zshare-generics=y" below.
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-Clink-arg=-fuse-ld=lld", "-Zshare-generics=y"]
+
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe"
 rustflags = ["-Zshare-generics=off"]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if cfg!(target_os = "linux") {
+        println!("cargo:rustc-link-lib=vulkan");
+    }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,52 @@
+{
+  description = "template";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    nix-fmt.url = "github:nix-community/nixpkgs-fmt";
+  };
+
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils, nix-fmt, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+      in
+      with pkgs;
+      {
+        devShell = mkShell {
+          shellHook = ''export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${pkgs.lib.makeLibraryPath [
+            pkgs.alsaLib
+            pkgs.udev
+            pkgs.vulkan-loader
+          ]}"'';
+
+          buildInputs = [
+            (rust-bin.selectLatestNightlyWith (toolchain: toolchain.default.override {
+              extensions = [ "rust-src" ];
+            }))
+            cargo
+            pkgconfig
+            udev
+            alsaLib
+            x11
+            xorg.libXcursor
+            xorg.libXrandr
+            xorg.libXi
+            vulkan-tools
+            vulkan-headers
+            vulkan-loader
+            vulkan-validation-layers
+            clang
+            lld
+            nixpkgs-fmt
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
Adds a basic flake.nix file using the oxalica Rust overlay, nixpkgs-fmt, and build and runtime dependencies for Bevy; sets up lld as the linker on linux, and adds a build.rs file to ensure proper linking with Vulkan.