### PR TITLE
Bevy 0.11 updates

### DIFF
--- a/template_game/Cargo.toml
+++ b/template_game/Cargo.toml
@@ -6,5 +6,5 @@ authors = ["Leafwing Studios"]
 edition = "2021"
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", rev="f7fbfaf", default-features = false}
+bevy = { git = "https://github.com/bevyengine/bevy", rev="12c6fa7", default-features = false}
 template_lib ={ path = "../template_lib", version = "0.1"}

--- a/template_game/src/main.rs
+++ b/template_game/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugin(template_lib::player::PlayerPlugin)
-        .add_plugin(template_lib::graphics::GraphicsPlugin)
+        .add_plugins(template_lib::player::PlayerPlugin)
+        .add_plugins(template_lib::graphics::GraphicsPlugin)
         .run();
 }

--- a/template_lib/Cargo.toml
+++ b/template_lib/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache 2.0"
 edition = "2021"
 
 [dependencies]
-bevy = { git = "https://github.com/bevyengine/bevy", rev="f7fbfaf", default-features = false, features = [
+bevy = { git = "https://github.com/bevyengine/bevy", rev="12c6fa7", default-features = false, features = [
     "bevy_asset",
     "bevy_core_pipeline",
     "bevy_gilrs",

--- a/template_lib/src/graphics/lighting.rs
+++ b/template_lib/src/graphics/lighting.rs
@@ -12,7 +12,7 @@ impl Plugin for LightingPlugin {
             brightness: 1.,
             color: Color::WHITE,
         })
-        .add_startup_system(spawn_sun);
+        .add_systems(Startup, spawn_sun);
     }
 }
 

--- a/template_lib/src/graphics/mod.rs
+++ b/template_lib/src/graphics/mod.rs
@@ -12,7 +12,7 @@ pub struct GraphicsPlugin;
 
 impl Plugin for GraphicsPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugin(LightingPlugin);
+        app.add_plugins(LightingPlugin);
     }
 }
 

--- a/template_lib/src/player/camera.rs
+++ b/template_lib/src/player/camera.rs
@@ -7,7 +7,7 @@ pub struct CameraPlugin;
 
 impl Plugin for CameraPlugin {
     fn build(&self, app: &mut App) {
-        app.add_startup_system(camera_setup);
+        app.add_systems(Startup, camera_setup);
     }
 }
 

--- a/template_lib/src/player/mod.rs
+++ b/template_lib/src/player/mod.rs
@@ -8,6 +8,6 @@ pub struct PlayerPlugin;
 
 impl Plugin for PlayerPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugin(camera::CameraPlugin);
+        app.add_plugins(camera::CameraPlugin);
     }
 }


### PR DESCRIPTION
Updated `add_systems` and `add_plugins` methods as per the Bevy 0.11 migration guide. 
Used the commit hash from the 0.11.2 release.